### PR TITLE
Dynamic sources form part 1.

### DIFF
--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -84,6 +84,14 @@ const CopyFilesWebpackPlugin = new (require('copy-webpack-plugin'))([
 plugins.push(CopyFilesWebpackPlugin);
 
 /**
+ * Makes build-time env vars available to the client-side as constants
+ */
+const envPlugin = new webpack.DefinePlugin({
+    'process.env.BASE_PATH': JSON.stringify(process.env.BASE_PATH || '/r/insights/platform')
+});
+plugins.push(envPlugin);
+
+/**
  * Replaces any @@insights in the html files with config.insightsDeployment value.
  * This handles the path being either insights or insightsbeta in the esi:include.
  */

--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -20,122 +20,123 @@ export const providerForm = {
 };
 
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
-export const wizardForm = {
-    initialValues: {
-        role: 'kubernetes', // 'aws' for AWS EC2
-        verify_ssl: true
-    },
-    schemaType: 'default',
-    showFormControls: false,
-    schema: {
-        fields: [{
-            component: componentTypes.WIZARD,
-            name: 'wizzard',
-            assignFieldProvider: true,
+
+const compileSourcesComboOptions = (sourceTypes) => (
+    [{ label: 'Please Choose' }].concat(
+       sourceTypes.map(t => ({
+           value: t.id,
+           label: t.product_name
+       }))
+    )
+);
+
+export function wizardForm(sourceTypes) {
+    return {
+        initialValues: {
+            role: 'kubernetes', // 'aws' for AWS EC2
+            verify_ssl: true
+        },
+        schemaType: 'default',
+        showFormControls: false,
+        schema: {
             fields: [{
-                title: 'Get started with adding source',
-                name: 'step-1',
-                stepKey: 1,
-                nextStep: {
-                    when: 'source_type',
-                    stepMapper: {
-                        amazon: 'amazon',
-                        google: 'google',
-                        openshift: 'openshift'
-                    }
-                },
+                component: componentTypes.WIZARD,
+                name: 'wizzard',
+                assignFieldProvider: true,
                 fields: [{
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'source_name',
-                    type: 'text',
-                    label: 'Name'
-                }, {
-                    component: componentTypes.SELECT_COMPONENT,
-                    name: 'source_type',
-                    label: 'Source type',
-                    isRequired: true,
-                    options: [{
-                        label: 'Please Choose'
+                    title: 'Get started with adding source',
+                    name: 'step-1',
+                    stepKey: 1,
+                    nextStep: {
+                        when: 'source_type',
+                        stepMapper: {
+                            amazon: 'amazon',
+                            google: 'google',
+                            openshift: 'openshift'
+                        }
+                    },
+                    fields: [{
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'source_name',
+                        type: 'text',
+                        label: 'Name'
                     }, {
-                        value: 'openshift',
-                        label: 'OpenShift'
-                    }, {
-                        value: 'amazon',
-                        label: 'AWS EC2'
-                    }/*, {
-                        value: 'google',
-                        label: 'Google Compute'
-                    }*/],
-                    validate: [{
-                        type: validatorTypes.REQUIRED
+                        component: componentTypes.SELECT_COMPONENT,
+                        name: 'source_type',
+                        label: 'Source type',
+                        isRequired: true,
+                        options: compileSourcesComboOptions(sourceTypes),
+                        validate: [{
+                            type: validatorTypes.REQUIRED
+                        }]
                     }]
+                }, {
+                    title: 'Configure OpenShift',
+                    name: 'step-4',
+                    stepKey: 'openshift',
+                    nextStep: 'summary',
+                    fields: [{
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'role',
+                        type: 'hidden'
+                    }, {
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'url',
+                        label: 'URL'
+                    }, {
+                        component: componentTypes.CHECKBOX,
+                        name: 'verify_ssl',
+                        label: 'Verify SSL'
+                    }, {
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'certificate_authority',
+                        label: 'Certificate Authority',
+                        condition: {
+                            when: 'verify_ssl',
+                            is: true
+                        }
+                    }, {
+                        component: componentTypes.TEXTAREA_FIELD,
+                        name: 'token',
+                        label: 'Token'
+                    }]
+                }, {
+                    title: 'Configure AWS',
+                    name: 'step-2',
+                    stepKey: 'amazon',
+                    nextStep: 'summary',
+                    fields: [{
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'user_name',
+                        label: 'Access Key'
+                    }, {
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'password',
+                        label: 'Secret Key'
+                    }]
+                }, {
+                    stepKey: 'google',
+                    title: 'Configure google',
+                    name: 'step-3',
+                    nextStep: 'summary',
+                    fields: [{
+                        component: componentTypes.TEXT_FIELD,
+                        name: 'google-field',
+                        label: 'Google field part'
+                    }]
+                }, {
+                    fields: [{
+                        name: 'summary',
+                        component: 'summary',
+                        assignFieldProvider: true
+                    }],
+                    stepKey: 'summary',
+                    name: 'summary'
                 }]
-            }, {
-                title: 'Configure OpenShift',
-                name: 'step-4',
-                stepKey: 'openshift',
-                nextStep: 'summary',
-                fields: [{
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'role',
-                    type: 'hidden'
-                }, {
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'url',
-                    label: 'URL'
-                }, {
-                    component: componentTypes.CHECKBOX,
-                    name: 'verify_ssl',
-                    label: 'Verify SSL'
-                }, {
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'certificate_authority',
-                    label: 'Certificate Authority',
-                    condition: {
-                        when: 'verify_ssl',
-                        is: true
-                    }
-                }, {
-                    component: componentTypes.TEXTAREA_FIELD,
-                    name: 'token',
-                    label: 'Token'
-                }]
-            }, {
-                title: 'Configure AWS',
-                name: 'step-2',
-                stepKey: 'amazon',
-                nextStep: 'summary',
-                fields: [{
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'user_name',
-                    label: 'Access Key'
-                }, {
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'password',
-                    label: 'Secret Key'
-                }]
-            }, {
-                stepKey: 'google',
-                title: 'Configure google',
-                name: 'step-3',
-                nextStep: 'summary',
-                fields: [{
-                    component: componentTypes.TEXT_FIELD,
-                    name: 'google-field',
-                    label: 'Google field part'
-                }]
-            }, {
-                fields: [{
-                    name: 'summary',
-                    component: 'summary',
-                    assignFieldProvider: true
-                }],
-                stepKey: 'summary',
-                name: 'summary'
             }]
-        }]
-    },
-    uiSchema: {
-    //password: {'ui:widget': 'password'}
+        },
+        uiSchema: {
+        //password: {'ui:widget': 'password'}
+        }
     }
 };

--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -23,10 +23,10 @@ import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-re
 
 const compileSourcesComboOptions = (sourceTypes) => (
     [{ label: 'Please Choose' }].concat(
-       sourceTypes.map(t => ({
-           value: t.id,
-           label: t.product_name
-       }))
+        sourceTypes.map(t => ({
+            value: t.name,
+            label: t.product_name
+        }))
     )
 );
 
@@ -138,5 +138,7 @@ export function wizardForm(sourceTypes) {
         uiSchema: {
         //password: {'ui:widget': 'password'}
         }
-    }
-};
+    };
+}
+
+;

--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -30,11 +30,101 @@ const compileSourcesComboOptions = (sourceTypes) => (
     )
 );
 
+const temporatyHardcodedSourceSchemas = {
+    openshift: {
+        title: 'Configure OpenShift',
+        name: 'step-4',
+        stepKey: 'openshift',
+        nextStep: 'summary',
+        fields: [{
+            component: componentTypes.TEXT_FIELD,
+            name: 'role',
+            type: 'hidden'
+        }, {
+            component: componentTypes.TEXT_FIELD,
+            name: 'url',
+            label: 'URL'
+        }, {
+            component: componentTypes.CHECKBOX,
+            name: 'verify_ssl',
+            label: 'Verify SSL'
+        }, {
+            component: componentTypes.TEXT_FIELD,
+            name: 'certificate_authority',
+            label: 'Certificate Authority',
+            condition: {
+                when: 'verify_ssl',
+                is: true
+            }
+        }, {
+            component: componentTypes.TEXTAREA_FIELD,
+            name: 'token',
+            label: 'Token'
+        }]
+    },
+    amazon: {
+        title: 'Configure AWS',
+        name: 'step-2',
+        stepKey: 'amazon',
+        nextStep: 'summary',
+        fields: [{
+            component: componentTypes.TEXT_FIELD,
+            name: 'user_name',
+            label: 'Access Key'
+        }, {
+            component: componentTypes.TEXT_FIELD,
+            name: 'password',
+            label: 'Secret Key'
+        }]
+    }
+};
+
+const compileStepMapper = (_sourceTypes) => ({
+    amazon: 'amazon',
+    google: 'google',
+    openshift: 'openshift'
+});
+
+const firstStep = (sourceTypes) => ({
+    title: 'Get started with adding source',
+    name: 'step-1',
+    stepKey: 1,
+    nextStep: {
+        when: 'source_type',
+        stepMapper: compileStepMapper(sourceTypes)
+    },
+    fields: [{
+        component: componentTypes.TEXT_FIELD,
+        name: 'source_name',
+        type: 'text',
+        label: 'Name'
+    }, {
+        component: componentTypes.SELECT_COMPONENT,
+        name: 'source_type',
+        label: 'Source type',
+        isRequired: true,
+        options: compileSourcesComboOptions(sourceTypes),
+        validate: [{
+            type: validatorTypes.REQUIRED
+        }]
+    }]
+});
+
+const summaryStep = () => ({
+    fields: [{
+        name: 'summary',
+        component: 'summary',
+        assignFieldProvider: true
+    }],
+    stepKey: 'summary',
+    name: 'summary'
+});
+
 export function wizardForm(sourceTypes) {
     return {
         initialValues: {
             role: 'kubernetes', // 'aws' for AWS EC2
-            verify_ssl: true
+            verify_ssl: true    // for OpenShift
         },
         schemaType: 'default',
         showFormControls: false,
@@ -43,96 +133,12 @@ export function wizardForm(sourceTypes) {
                 component: componentTypes.WIZARD,
                 name: 'wizzard',
                 assignFieldProvider: true,
-                fields: [{
-                    title: 'Get started with adding source',
-                    name: 'step-1',
-                    stepKey: 1,
-                    nextStep: {
-                        when: 'source_type',
-                        stepMapper: {
-                            amazon: 'amazon',
-                            google: 'google',
-                            openshift: 'openshift'
-                        }
-                    },
-                    fields: [{
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'source_name',
-                        type: 'text',
-                        label: 'Name'
-                    }, {
-                        component: componentTypes.SELECT_COMPONENT,
-                        name: 'source_type',
-                        label: 'Source type',
-                        isRequired: true,
-                        options: compileSourcesComboOptions(sourceTypes),
-                        validate: [{
-                            type: validatorTypes.REQUIRED
-                        }]
-                    }]
-                }, {
-                    title: 'Configure OpenShift',
-                    name: 'step-4',
-                    stepKey: 'openshift',
-                    nextStep: 'summary',
-                    fields: [{
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'role',
-                        type: 'hidden'
-                    }, {
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'url',
-                        label: 'URL'
-                    }, {
-                        component: componentTypes.CHECKBOX,
-                        name: 'verify_ssl',
-                        label: 'Verify SSL'
-                    }, {
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'certificate_authority',
-                        label: 'Certificate Authority',
-                        condition: {
-                            when: 'verify_ssl',
-                            is: true
-                        }
-                    }, {
-                        component: componentTypes.TEXTAREA_FIELD,
-                        name: 'token',
-                        label: 'Token'
-                    }]
-                }, {
-                    title: 'Configure AWS',
-                    name: 'step-2',
-                    stepKey: 'amazon',
-                    nextStep: 'summary',
-                    fields: [{
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'user_name',
-                        label: 'Access Key'
-                    }, {
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'password',
-                        label: 'Secret Key'
-                    }]
-                }, {
-                    stepKey: 'google',
-                    title: 'Configure google',
-                    name: 'step-3',
-                    nextStep: 'summary',
-                    fields: [{
-                        component: componentTypes.TEXT_FIELD,
-                        name: 'google-field',
-                        label: 'Google field part'
-                    }]
-                }, {
-                    fields: [{
-                        name: 'summary',
-                        component: 'summary',
-                        assignFieldProvider: true
-                    }],
-                    stepKey: 'summary',
-                    name: 'summary'
-                }]
+                fields: [
+                    firstStep(sourceTypes),
+                    temporatyHardcodedSourceSchemas.openshift,
+                    temporatyHardcodedSourceSchemas.amazon,
+                    summaryStep()
+                ]
             }]
         },
         uiSchema: {

--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -101,8 +101,7 @@ const firstStep = (sourceTypes) => ({
 const summaryStep = () => ({
     fields: [{
         name: 'summary',
-        component: 'summary',
-        assignFieldProvider: true
+        component: 'summary'
     }],
     stepKey: 'summary',
     name: 'summary'
@@ -125,15 +124,11 @@ export function wizardForm(sourceTypes) {
             fields: [{
                 component: componentTypes.WIZARD,
                 name: 'wizzard',
-                assignFieldProvider: true,
                 fields: [firstStep(sourceTypes)].concat(
                     sourceTypes.map(t => fieldsToStep(sourceTypeSchema(t), t.name, 'summary')),
                     summaryStep()
                 )
             }]
-        },
-        uiSchema: {
-        //password: {'ui:widget': 'password'}
         }
     };
 }

--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -61,6 +61,9 @@ const temporaryHardcodedSourceSchemas = {
     }
 };
 
+console.log(JSON.stringify(temporaryHardcodedSourceSchemas.openshift));
+console.log(JSON.stringify(temporaryHardcodedSourceSchemas.amazon));
+
 /* Fall-back to hard-coded schemas */
 const sourceTypeSchema = t => (t.schema || temporaryHardcodedSourceSchemas[t.name]);
 

--- a/src/Utilities/Constants.js
+++ b/src/Utilities/Constants.js
@@ -1,0 +1,1 @@
+export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topological-inventory/v0.0`;

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -37,12 +37,15 @@ const sourceType2ProviderSpecific = source_type => {
     }
 };
 
-export function doRemoveSource(sourceId) {
+export function getApiInstance() {
     let apiInstance = new TopologicalInventory.DefaultApi();
     let defaultClient = TopologicalInventory.ApiClient.instance;
     defaultClient.basePath = SOURCES_API_BASE;
+    return apiInstance;
+}
 
-    return apiInstance.deleteSource(sourceId).then((sourceDataOut) => {
+export function doRemoveSource(sourceId) {
+    return getApiInstance.deleteSource(sourceId).then((sourceDataOut) => {
         console.log('API call deleteSource returned data: ', sourceDataOut);
     }, (_error) => {
         console.error('Source removal failed.');
@@ -50,12 +53,8 @@ export function doRemoveSource(sourceId) {
     });
 }
 
-export function doCreateSource (formData) {
+export function doCreateSource(formData) {
     console.log('doCreateSource', formData);
-    let apiInstance = new TopologicalInventory.DefaultApi();
-
-    let defaultClient = TopologicalInventory.ApiClient.instance;
-    defaultClient.basePath = SOURCES_API_BASE;
 
     // lookup hard-coded values
     const providerData = sourceType2ProviderSpecific(formData.source_type);
@@ -66,7 +65,7 @@ export function doCreateSource (formData) {
         source_type_id: providerData.source_type
     };
 
-    return apiInstance.createSource(sourceData).then((sourceDataOut) => {
+    return getApiInstance.createSource(sourceData).then((sourceDataOut) => {
         console.log('API call createSource returned data: ', sourceDataOut);
 
         // For now we parse these from a single 'URL' field.

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,4 +1,4 @@
-export const SOURCES_API_BASE = '/r/insights/platform/topological-inventory/v0.0';
+import { TOPOLOGICAL_INVENTORY_API_BASE } from '../Utilities/Constants';
 import { sourcesViewDefinition } from '../views/sourcesViewDefinition';
 
 export function getEntities () {
@@ -46,7 +46,7 @@ export function getApiInstance() {
 
     apiInstance = new TopologicalInventory.DefaultApi();
     let defaultClient = TopologicalInventory.ApiClient.instance;
-    defaultClient.basePath = SOURCES_API_BASE;
+    defaultClient.basePath = TOPOLOGICAL_INVENTORY_API_BASE;
     return apiInstance;
 }
 

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -37,15 +37,21 @@ const sourceType2ProviderSpecific = source_type => {
     }
 };
 
+let apiInstance;
+
 export function getApiInstance() {
-    let apiInstance = new TopologicalInventory.DefaultApi();
+    if (apiInstance) {
+        return apiInstance;
+    }
+
+    apiInstance = new TopologicalInventory.DefaultApi();
     let defaultClient = TopologicalInventory.ApiClient.instance;
     defaultClient.basePath = SOURCES_API_BASE;
     return apiInstance;
 }
 
 export function doRemoveSource(sourceId) {
-    return getApiInstance.deleteSource(sourceId).then((sourceDataOut) => {
+    return getApiInstance().deleteSource(sourceId).then((sourceDataOut) => {
         console.log('API call deleteSource returned data: ', sourceDataOut);
     }, (_error) => {
         console.error('Source removal failed.');
@@ -65,7 +71,7 @@ export function doCreateSource(formData) {
         source_type_id: providerData.source_type
     };
 
-    return getApiInstance.createSource(sourceData).then((sourceDataOut) => {
+    return getApiInstance().createSource(sourceData).then((sourceDataOut) => {
         console.log('API call createSource returned data: ', sourceDataOut);
 
         // For now we parse these from a single 'URL' field.
@@ -92,7 +98,7 @@ export function doCreateSource(formData) {
             certificate_authority: formData.certificate_authority
         };
 
-        return apiInstance.createEndpoint(endpointData).then((endpointDataOut) => {
+        return getApiInstance().createEndpoint(endpointData).then((endpointDataOut) => {
             console.log('API call createEndpoint returned data: ', endpointDataOut);
 
             const authenticationData = {
@@ -102,7 +108,7 @@ export function doCreateSource(formData) {
                 password: formData.token
             };
 
-            return apiInstance.createAuthentication(authenticationData).then((authenticationDataOut) => {
+            return getApiInstance().createAuthentication(authenticationData).then((authenticationDataOut) => {
                 console.log('API call createAuthentication returned data: ', authenticationDataOut);
 
                 return authenticationDataOut;

--- a/src/api/source_types.js
+++ b/src/api/source_types.js
@@ -1,9 +1,9 @@
-import { getApiInstance } from './entities.js'
+import { getApiInstance } from './entities.js';
 
 export function doLoadSourceTypes() {
     let opts = {
-      'limit': 100,
-      'offset': 0
+        limit: 100,
+        offset: 0
     };
     return getApiInstance().listSourceTypes(opts).then((data) => {
         console.log('API called successfully. Returned data: ', data);
@@ -12,4 +12,6 @@ export function doLoadSourceTypes() {
         console.error(error);
         return [];
     });
-};
+}
+
+;

--- a/src/api/source_types.js
+++ b/src/api/source_types.js
@@ -1,0 +1,15 @@
+import { getApiInstance } from './entities.js'
+
+export function doLoadSourceTypes() {
+    let opts = {
+      'limit': 100,
+      'offset': 0
+    };
+    return getApiInstance().listSourceTypes(opts).then((data) => {
+        console.log('API called successfully. Returned data: ', data);
+        return data;
+    }, (error) => {
+        console.error(error);
+        return [];
+    });
+};

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { PageHeader, PageHeaderTitle, Pagination, Section } from '@red-hat-insights/insights-frontend-components';
 
 //import './provider-page.scss';
-import { addProvider, createSource, filterProviders, loadEntities } from '../redux/actions/providers';
+import { addProvider, createSource, filterProviders, loadEntities, loadSourceTypes } from '../redux/actions/providers';
 
 import { Button } from '@patternfly/react-core';
 import { Card, CardBody, CardFooter, Modal } from '@patternfly/react-core';
@@ -33,13 +33,19 @@ class SourcesPage extends Component {
         createSource: PropTypes.func.isRequired,
         filterProviders: PropTypes.func.isRequired,
         loadEntities: PropTypes.func.isRequired,
+        loadSourceTypes: PropTypes.func.isRequired,
         pageAndSize: PropTypes.func.isRequired,
 
         numberOfEntities: PropTypes.number.isRequired,
+        sourceTypes: PropTypes.arrayOf(PropTypes.any),
 
         location: PropTypes.any.isRequired,
         history: PropTypes.any.isRequired
     };
+
+    componentDidMount = () => {
+        this.props.loadSourceTypes();
+    }
 
     constructor (props) {
         super(props);
@@ -83,7 +89,7 @@ class SourcesPage extends Component {
     render = () => {
         // const filterColumns = filter(providerColumns, c => c.value);
 
-        const form = wizardForm;
+        const form = wizardForm(this.props.sourceTypes || []);
 
         return (
             <React.Fragment>
@@ -134,8 +140,9 @@ class SourcesPage extends Component {
 }
 
 const mapDispatchToProps = dispatch => bindActionCreators(
-    { addProvider, createSource, filterProviders, loadEntities, pageAndSize }, dispatch);
+    { addProvider, createSource, filterProviders, loadEntities,
+        loadSourceTypes, pageAndSize }, dispatch);
 
-const mapStateToProps = ({ providers: { numberOfEntities } }) => ({ numberOfEntities });
+const mapStateToProps = ({ providers: { numberOfEntities, sourceTypes } }) => ({ numberOfEntities, sourceTypes });
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(SourcesPage));

--- a/src/redux/action-types-providers.js
+++ b/src/redux/action-types-providers.js
@@ -1,7 +1,8 @@
 const asyncActions = [
     'LOAD_ENTITIES',
     'CREATE_SOURCE',
-    'REMOVE_SOURCE'
+    'REMOVE_SOURCE',
+    'LOAD_SOURCE_TYPES'
 ].reduce((acc, curr) => [
     ... acc,
     ...[curr, `${curr}_PENDING`, `${curr}_FULFILLED`, `${curr}_REJECTED`]

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -83,5 +83,5 @@ export const removeSource = (sourceId) => {
 
 export const loadSourceTypes = () => ({
     type: ACTION_TYPES.LOAD_SOURCE_TYPES,
-    payload: doLoadSourceTypes(),
+    payload: doLoadSourceTypes()
 });

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -3,6 +3,7 @@ import {
     ADD_PROVIDER, FILTER_PROVIDERS, CLOSE_ALERT, ADD_ALERT
 } from '../action-types-providers';
 import { getEntities, doCreateSource, doRemoveSource } from '../../api/entities';
+import { doLoadSourceTypes } from '../../api/source_types';
 
 export const loadEntities = () => ({
     type: ACTION_TYPES.LOAD_ENTITIES,
@@ -79,3 +80,8 @@ export const removeSource = (sourceId) => {
         }
     };
 };
+
+export const loadSourceTypes = () => ({
+    type: ACTION_TYPES.LOAD_SOURCE_TYPES,
+    payload: doLoadSourceTypes(),
+});

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -11,12 +11,6 @@ export const defaultProvidersState = {
     numberOfEntities: 0
 };
 
-const entitiesPending = (state) => ({
-    ...state,
-    loaded: false,
-    expanded: null
-});
-
 const processListInState = (state) => {
     const { length, list } = processList(state.rows, state);
 
@@ -27,12 +21,28 @@ const processListInState = (state) => {
     };
 };
 
+const entitiesPending = (state) => ({
+    ...state,
+    loaded: false,
+    expanded: null
+});
+
 const entitiesLoaded = (state, { payload: rows }) =>
     processListInState({
         ...state,
         loaded: true,
         rows
     });
+
+const sourceTypesPending = (state) => ({
+    ...state,
+    sourceTypes: [],
+});
+
+const sourceTypesLoaded = (state, { payload: sourceTypes }) => ({
+    ...state,
+    sourceTypes,
+});
 
 const selectEntity = (state, { payload: { id, selected } }) => ({
     ...state,
@@ -117,6 +127,8 @@ export default {
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,
     //    [ACTION_TYPES.CREATE_SOURCE_PENDING]: createSourcePending,
     //    [ACTION_TYPES.CREATE_SOURCE_FULFILLED]: createSourceFulFilled,
+    [ACTION_TYPES.LOAD_SOURCE_TYPES_PENDING]: sourceTypesPending,
+    [ACTION_TYPES.LOAD_SOURCE_TYPES_FULFILLED]: sourceTypesLoaded,
 
     [SELECT_ENTITY]: selectEntity,
     [EXPAND_ENTITY]: expandEntity,

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -36,12 +36,12 @@ const entitiesLoaded = (state, { payload: rows }) =>
 
 const sourceTypesPending = (state) => ({
     ...state,
-    sourceTypes: [],
+    sourceTypes: []
 });
 
 const sourceTypesLoaded = (state, { payload: sourceTypes }) => ({
     ...state,
-    sourceTypes,
+    sourceTypes
 });
 
 const selectEntity = (state, { payload: { id, selected } }) => ({


### PR DESCRIPTION
Initial steps on making the form sources form generated from the API.

It's problematic if this makes sense because as sources will be registered for several/different apps with different requirements, different fields in the form will be needed.

At that point a more complex logic, one that counts on the different apps will be needed.

### Done

 * load the list of sources
 * generate the combo with list of sources
  * generate pages of the wizzard
  * generate proper sequence of steps/pages

### TODO (another PR)
  * move the form definition to the sources database (entity SourceType) -- first need to add it to https://github.com/martinpovolny/topological_inventory-core
