### PR TITLE
Dynamic sources form part 2

### DIFF
--- a/src/SmartComponents/ProviderPage/providerForm.js
+++ b/src/SmartComponents/ProviderPage/providerForm.js
@@ -61,9 +61,6 @@ const temporaryHardcodedSourceSchemas = {
     }
 };
 
-console.log(JSON.stringify(temporaryHardcodedSourceSchemas.openshift));
-console.log(JSON.stringify(temporaryHardcodedSourceSchemas.amazon));
-
 /* Fall-back to hard-coded schemas */
 const sourceTypeSchema = t => (t.schema || temporaryHardcodedSourceSchemas[t.name]);
 

--- a/src/Utilities/Constants.js
+++ b/src/Utilities/Constants.js
@@ -1,1 +1,14 @@
-export const TOPOLOGICAL_INVENTORY_API_BASE = `${process.env.BASE_PATH}/topological-inventory/v0.0`;
+/* If BASE_PATH ends with '/', append just the version. This is useful for local debugging:
+ *
+ * BASE_PATH=http://lucifer.usersys.redhat.com:4000/api/ npm run start
+ *
+ * Will correctly work with a local running Inventory API (bundle exec rails s -b 0.0.0.0 -p 4000).
+ *
+ *
+ * Else append the microservice path and version. This behavior is compatible with Service Catalog.
+ */
+const calculateApiBase = b => (
+    (b.endsWith('/') && `${b}v0.0`) || `${b}/topological-inventory/v0.0`
+);
+
+export const TOPOLOGICAL_INVENTORY_API_BASE = calculateApiBase(process.env.BASE_PATH || '');

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -2,7 +2,7 @@ import { TOPOLOGICAL_INVENTORY_API_BASE } from '../Utilities/Constants';
 import { sourcesViewDefinition } from '../views/sourcesViewDefinition';
 
 export function getEntities () {
-    return fetch(sourcesViewDefinition.url).then(r => {
+    return fetch(TOPOLOGICAL_INVENTORY_API_BASE + sourcesViewDefinition.url).then(r => {
         if (r.ok || r.type === 'opaque') {
             return r.json();
         }

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -1,6 +1,6 @@
 export const sourcesViewDefinition = {
     displayName: 'Sources',
-    url: '/r/insights/platform/topological-inventory/v0.0/sources/',
+    url: '/sources/',
     /* [{"id":"1","name":"OCP","uid":"29e1facc-c769-48d2-914f-c6682314cf54","created_at":"2018-10-25T14:19:27.252Z",
         "updated_at":"2018-10-25T14:19:27.252Z","tenant_id":1}, {"id":"2","name":"foo","uid":null,
         "created_at":"2018-11-01T11:24:24.767Z","updated_at":"2018-11-01T11:24:24.767Z","tenant_id":1}] */


### PR DESCRIPTION
Carrying on with the work from:  https://github.com/ManageIQ/topological_inventory-ui/pull/17

These changes are needed to properly set the BASE_PATH from the command line.

Example:
```
BASE_PATH=http://lucifer.usersys.redhat.com:4000/api/ npm run start
```

It will work together with: https://github.com/ManageIQ/topological_inventory-core/pull/107 but there's a fall back to hard-coded schema so it will work w/o the related PR also.

### TODO (another PR)
 * get rid of hard-coded parts