### PR TITLE
Use plain fetch to get source_types.

### DIFF
--- a/src/api/source_types.js
+++ b/src/api/source_types.js
@@ -1,16 +1,27 @@
-import { getApiInstance } from './entities.js';
+import { TOPOLOGICAL_INVENTORY_API_BASE } from '../Utilities/Constants';
+// import { getApiInstance } from './entities.js';
 
 export function doLoadSourceTypes() {
-    let opts = {
-        limit: 100,
-        offset: 0
-    };
-    return getApiInstance().listSourceTypes(opts).then((data) => {
-        return data.data;
-    }, (error) => {
-        console.error(error);
-        return [];
-    });
+    return fetch(TOPOLOGICAL_INVENTORY_API_BASE + '/source_types')
+    .then(r => r.json())
+    .then(data => data.data);
+
+    /*  FIXME: the API is broken now, data is returned as "Object object" so switching
+     *  to fetch() for now.
+     *
+     *  let opts = {
+     *      limit: 100,
+     *      offset: 0
+     *  };
+     *
+     *  return getApiInstance().listSourceTypes(opts).then((data) => {
+     *      console.log('data: ', data.data);
+     *      return data.data;
+     *  }, (error) => {
+     *      console.error(error);
+     *      return [];
+     *  });
+    */
 }
 
 ;


### PR DESCRIPTION
There's something broken with the javascript API client.

Using plain `fetch` for now.