### PR TITLE
Update routes based on new cloud changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Note: You will need to set up the Insights environment if you want to develop
 with the starter app due to the consumption of the chroming service as well as
 setting up your global/app navigation through the API.
 
+## Running locally
+Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH
+
+```shell
+SPANDX_CONFIG="./config/spandx.config.js" bash $PROXY_PATH/scripts/run.sh
+```
+
+
 ## Build app
 
 1. ```npm install```

--- a/config/base.webpack.plugins.js
+++ b/config/base.webpack.plugins.js
@@ -92,22 +92,14 @@ const envPlugin = new webpack.DefinePlugin({
 plugins.push(envPlugin);
 
 /**
- * Replaces any @@insights in the html files with config.insightsDeployment value.
+ * Replaces any @@insights in the html files with config.deploymentEnv value.
  * This handles the path being either insights or insightsbeta in the esi:include.
  */
 const HtmlReplaceWebpackPlugin = new(require('html-replace-webpack-plugin'))([{
-    pattern: '@@insights',
-    replacement: config.insightsDeployment
+    pattern: '@@env',
+    replacement: config.deploymentEnv
 }]);
 plugins.push(HtmlReplaceWebpackPlugin);
-
-/**
- * Replaces any instance of RELEASE in js files with config.insightsDeployment value.
- */
-const Release = new webpack.DefinePlugin({
-    RELEASE: JSON.stringify(config.insightsDeployment)
-});
-plugins.push(Release);
 
 /**
  * HMR

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -10,7 +10,7 @@ webpackConfig.serve = {
     content: config.paths.public,
     port: 8002,
     dev: {
-        publicPath: '/insights/platform/topological-inventory'
+        publicPath: config.paths.publicPath
     },
     // https://github.com/webpack-contrib/webpack-serve/blob/master/docs/addons/history-fallback.config.js
     add: app => app.use(convert(history({})))

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,0 +1,14 @@
+/*global module, process*/
+
+// Hack so that Mac OSX docker can sub in host.docker.internal instead of localhost
+// see https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
+const localhost = (process.env.PLATFORM === 'linux') ? 'localhost' : 'host.docker.internal';
+
+module.exports = {
+    routes: {
+        '/hcm/sources': { host: `http://${localhost}:8002` },
+        '/apps/sources': { host: `http://${localhost}:8002` },
+        '/apps/chrome': { host: 'https://ci.cloud.paas.upshift.redhat.com' },
+        '/r/insights/platform': { host: 'https://access.ci.cloud.paas.upshift.redhat.com' }
+    }
+};

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -9,17 +9,17 @@ const entry = process.env.NODE_ENV === 'production' ?
     path.resolve(__dirname, '../src/entry.js') :
     path.resolve(__dirname, '../src/entry-dev.js');
 
-let insightsDeployment = 'insights';
+let deploymentEnv = 'apps';
 const gitBranch = process.env.BRANCH || gitRevisionPlugin.branch();
 const betaBranch =
     gitBranch === 'ci-beta' ||
     gitBranch === 'qa-beta' ||
     gitBranch === 'prod-beta';
 if (process.env.NODE_ENV === 'production' && betaBranch) {
-    insightsDeployment = 'insightsbeta';
+    deploymentEnv = 'beta/apps';
 }
 
-const publicPath = `/${insightsDeployment}/platform/topological-inventory/`;
+const publicPath = `/${deploymentEnv}/sources/`;
 
 module.exports = {
     paths: {
@@ -33,5 +33,5 @@ module.exports = {
         static: path.resolve(__dirname, '../static'),
         publicPath
     },
-    insightsDeployment
+    deploymentEnv
 };

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -5,18 +5,16 @@ import { Provider } from 'react-redux';
 //import ReducerRegistry from './Utilities/ReducerRegistry';
 import App from './App';
 
-// exposes webpack variable RELEASE
-/*global RELEASE:true*/
-/*eslint no-undef: "error"*/
+const pathName = window.location.pathname.split('/');
+pathName.shift();
 
-/**
- * Hooks up redux to app.
- *  https://redux.js.org/advanced/usage-with-react-router
- */
-console.log(App);
+if (pathName[0] === 'beta') {
+    pathName.shift();
+}
+
 ReactDOM.render(
     <Provider store={App.getRegistry().getStore()}>
-        <Router basename={ `/${RELEASE}/platform/topological-inventory` }>
+        <Router basename={`${pathName[0]}/${pathName[1]}` }>
             <App />
         </Router>
     </Provider>,

--- a/src/entry.js
+++ b/src/entry.js
@@ -4,13 +4,16 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import App from './App';
 
-// exposes webpack variable RELEASE
-/*global RELEASE:true*/
-/*eslint no-undef: "error"*/
+const pathName = window.location.pathname.split('/');
+pathName.shift();
+
+if (pathName[0] === 'beta') {
+    pathName.shift();
+}
 
 ReactDOM.render(
     <Provider store={App.getRegistry().getStore()}>
-        <Router basename={ `/${RELEASE}/platform/topological-inventory` }>
+        <Router basename={`${pathName[0]}/${pathName[1]}` }>
             <App />
         </Router>
     </Provider>,

--- a/src/index.html
+++ b/src/index.html
@@ -1,18 +1,14 @@
 <!DOCTYPE html>
 <html lang="en-US">
+
     <head>
         <meta charset="UTF-8">
-        <title>Red Hat Insights | Topological Inventory</title>
-        <esi:include src="/@@insights/static/chrome/snippets/head.html"/>
+        <title>Red Hat Cloud Services Software | Sources</title>
+        <esi:include src="/@@env/chrome/snippets/head.html" />
     </head>
+
     <body>
-        <div class="pf-c-background-image"></div>
-        <div class="pf-l-page pf-c-page" id="page">
-            <esi:include src="/@@insights/static/chrome/snippets/header.html"/>
-            <esi:include src="/@@insights/static/chrome/snippets/sidebar.html"/>
-            <main role="main" class="pf-l-page__main pf-c-page__main" id="root">
-                <esi:include src="/@@insights/static/chrome/snippets/footer.html"/>
-            </main>
-        </div>
+        <esi:include src="/@@env/chrome/snippets/body.html" />
     </body>
+
 </html>


### PR DESCRIPTION
Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH

```shell
SPANDX_CONFIG="./config/spandx.config.js" bash $PROXY_PATH/scripts/run.sh
```

It will be accessible on https://prod.foo.redhat.com:1337/hcm/sources
